### PR TITLE
将kratos.js中在jq doc.ready事件时执行的初始化逻辑公开出来以方便pjax等库使用

### DIFF
--- a/assets/js/kratos.js
+++ b/assets/js/kratos.js
@@ -171,7 +171,7 @@
         })
     }
 
-    $(function () {
+    window.initKratos = function () {
         accordionConfig()
         navbarConfig()
         tooltipConfig()
@@ -183,7 +183,8 @@
         donateConfig()
         consoleConfig()
         lightGalleryConfig()
-    })
+    };
+    $(window.initKratos);
 })()
 
 function grin(tag) {


### PR DESCRIPTION
[pjax](https://github.com/MoOx/pjax)是一个让wp主题等传统的非spa网页拥有类似spa的用户体验的老库，我目前需要在`pjax:complete`事件中来手动执行初始化逻辑，比如重新监听点击事件等任务

由于kratos.js中的以下函数是写在$()参数闭包里的：
https://github.com/seatonjiang/kratos/blob/069c0cfc9719d0e60875362d11a0868cfca32f1d/assets/js/kratos.js#L174-L186
所以我无法直接调用他们，目前实现是手动把他们复制粘贴过来执行

此pr通过将这些调用初始化函数公开到window.initKratos全局函数下，以便于外部调用